### PR TITLE
Add debugging helpers

### DIFF
--- a/js/dah-booking.js
+++ b/js/dah-booking.js
@@ -5,6 +5,7 @@
   $(function(){
 
     if ( typeof DAHBooking === 'undefined' ) return;
+    console.log('DAHBooking config', DAHBooking);
 
     const {
       restBase, ajaxUrl, propertyId, propertyName,
@@ -322,6 +323,8 @@ fetchAvailability(from, to, instance)
           depositDays,
           propertyThumbnail
         };
+        console.log('Submitting order', order);
+        window.DAHLastOrder = order;
         $.post(ajaxUrl,{
           action:'dah_save_order',
           order: JSON.stringify(order)
@@ -356,6 +359,8 @@ fetchAvailability(from, to, instance)
           JSON.parse(decodeURIComponent(raw)),
           formData
         );
+        console.log('Submitting booking form', booking);
+        window.DAHLastBooking = booking;
         fetch('/api/customer_sales_intent_email',{
           method:'POST',
           body: JSON.stringify(booking)


### PR DESCRIPTION
## Summary
- add debug helper function and constant in PHP
- log cookie/query data and REST errors
- surface debug info for shortcodes
- expose config and orders in JS for easier debugging

## Testing
- `node js/dah-booking.js > /dev/null` *(fails: jQuery is not defined)*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ad2fb05483338f61df1d3b2e399c